### PR TITLE
Added support for sub-issues and project updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
+
+# AI-DEs files
+.cursor/

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { LinearClientManager } from './utils/linear-client.js';
 import { issueStatusTools } from './tools/issue-statuses/index.js';
 import { issueTools } from './tools/issues/index.js';
 import { labelTools } from './tools/labels/index.js';
-import { myIssuesTools } from './tools/my-issues.js';
+// import { myIssuesTools } from './tools/my-issues.js'; // Duplicate - list_my_issues is already in issueTools
 import { projectMilestoneTools } from './tools/project-milestones/index.js';
 import { projectTools } from './tools/projects/index.js';
 import { teamTools } from './tools/teams/index.js';
@@ -53,7 +53,7 @@ const allTools = [
   ...userTools,
   ...issueStatusTools,
   ...labelTools,
-  ...myIssuesTools,
+  // ...myIssuesTools, // Removed duplicate - list_my_issues is already in issueTools
   ...projectMilestoneTools,
 ];
 

--- a/src/tools/issues/create_issue.ts
+++ b/src/tools/issues/create_issue.ts
@@ -14,6 +14,7 @@ const IssueCreateSchema = {
   labelIds: z.array(z.string()).optional().describe('Label IDs'),
   stateId: z.string().optional().describe('Workflow state ID'),
   projectId: z.string().optional().describe('Project ID to assign the issue to'),
+  projectMilestoneId: z.string().optional().describe('Project milestone ID to assign the issue to'),
 };
 import { mapIssueToDetails } from './shared.js';
 

--- a/src/tools/issues/create_issue.ts
+++ b/src/tools/issues/create_issue.ts
@@ -13,6 +13,7 @@ const IssueCreateSchema = {
   assigneeId: z.string().optional().describe('Assignee user ID'),
   labelIds: z.array(z.string()).optional().describe('Label IDs'),
   stateId: z.string().optional().describe('Workflow state ID'),
+  projectId: z.string().optional().describe('Project ID to assign the issue to'),
 };
 import { mapIssueToDetails } from './shared.js';
 

--- a/src/tools/issues/create_sub_issue.ts
+++ b/src/tools/issues/create_sub_issue.ts
@@ -1,0 +1,98 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+import { mapIssueToDetails } from './shared.js';
+
+const CreateSubIssueSchema = {
+  // Required fields
+  parentId: z.string().describe('The ID of the parent issue'),
+  title: z.string().describe('Sub-issue title'),
+  
+  // Optional fields (inherited from parent if not specified)
+  description: z.string().optional().describe('Sub-issue description in markdown'),
+  priority: z.number().optional().describe('Priority (0=None, 1=Urgent, 2=High, 3=Normal, 4=Low)'),
+  assigneeId: z.string().optional().describe('Assignee user ID'),
+  labelIds: z.array(z.string()).optional().describe('Label IDs'),
+  stateId: z.string().optional().describe('Workflow state ID'),
+  
+  // Sub-issue specific options
+  copyPropertiesFromParent: z.boolean().default(true).describe('Whether to copy project, cycle, and other properties from parent'),
+};
+
+export const createSubIssueTool = defineTool({
+  name: 'create_sub_issue',
+  description: 'Create a new sub-issue under a parent issue',
+  inputSchema: CreateSubIssueSchema,
+  handler: async ({ parentId, title, description, priority, assigneeId, labelIds, stateId, copyPropertiesFromParent }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Get the parent issue first to verify it exists and get team info
+      const parentIssue = await linearClient.issue(parentId);
+      if (!parentIssue) {
+        throw new McpError(ErrorCode.InvalidParams, `Parent issue with ID '${parentId}' not found.`);
+      }
+
+      // Build the create payload
+      const createPayload: any = {
+        title,
+        parentId,
+        teamId: parentIssue.teamId, // Sub-issues must be in the same team as parent
+        ...(description !== undefined && { description }),
+        ...(priority !== undefined && { priority }),
+        ...(assigneeId !== undefined && { assigneeId }),
+        ...(labelIds !== undefined && { labelIds }),
+        ...(stateId !== undefined && { stateId }),
+      };
+
+      // Copy properties from parent if requested
+      if (copyPropertiesFromParent) {
+        if (parentIssue.projectId) {
+          createPayload.projectId = parentIssue.projectId;
+        }
+        if (parentIssue.cycleId) {
+          createPayload.cycleId = parentIssue.cycleId;
+        }
+        if (parentIssue.projectMilestoneId) {
+          createPayload.projectMilestoneId = parentIssue.projectMilestoneId;
+        }
+      }
+
+      // Create the sub-issue
+      const issueCreate = await linearClient.createIssue(createPayload);
+      const newSubIssue = await issueCreate.issue;
+      
+      if (!newSubIssue) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to create sub-issue or retrieve details. Sync ID: ${issueCreate.lastSyncId}`
+        );
+      }
+
+      // Return detailed information about the created sub-issue
+      const detailedSubIssue = await mapIssueToDetails(newSubIssue, false, false);
+      
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify({
+            success: true,
+            subIssue: detailedSubIssue,
+            parentId,
+            parentTitle: parentIssue.title,
+            parentIdentifier: parentIssue.identifier,
+            syncId: issueCreate.lastSyncId
+          })
+        }] 
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create sub-issue: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 

--- a/src/tools/issues/index.ts
+++ b/src/tools/issues/index.ts
@@ -6,6 +6,12 @@ import { listIssuesTool } from './list_issues.js';
 import { listMyIssuesTool } from './list_my_issues.js';
 import { updateIssueTool } from './update_issue.js';
 
+// Sub-issue management tools
+import { listSubIssuesTool } from './list_sub_issues.js';
+import { createSubIssueTool } from './create_sub_issue.js';
+import { setIssueParentTool } from './set_issue_parent.js';
+import { removeIssueParentTool } from './remove_issue_parent.js';
+
 export const issueTools = [
   listIssuesTool,
   listMyIssuesTool,
@@ -14,4 +20,10 @@ export const issueTools = [
   getIssueGitBranchNameTool,
   listCommentsTool,
   updateIssueTool,
+  
+  // Sub-issue management tools
+  listSubIssuesTool,
+  createSubIssueTool,
+  setIssueParentTool,
+  removeIssueParentTool,
 ];

--- a/src/tools/issues/list_sub_issues.ts
+++ b/src/tools/issues/list_sub_issues.ts
@@ -1,0 +1,79 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+import { mapIssueToDetails } from './shared.js';
+
+const ListSubIssuesSchema = {
+  parentId: z.string().describe('The ID of the parent issue to list sub-issues for'),
+  includeDetails: z.boolean().default(false).describe('Whether to include detailed information for each sub-issue'),
+};
+
+export const listSubIssuesTool = defineTool({
+  name: 'list_sub_issues',
+  description: 'List sub-issues for a given parent issue',
+  inputSchema: ListSubIssuesSchema,
+  handler: async ({ parentId, includeDetails }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Get the parent issue first to verify it exists
+      const parentIssue = await linearClient.issue(parentId);
+      if (!parentIssue) {
+        throw new McpError(ErrorCode.InvalidParams, `Parent issue with ID '${parentId}' not found.`);
+      }
+
+      // Get the sub-issues (children)
+      const subIssuesConnection = await parentIssue.children();
+      
+      if (includeDetails) {
+        // Map each sub-issue to detailed format
+        const detailedSubIssues = await Promise.all(
+          subIssuesConnection.nodes.map(subIssue => mapIssueToDetails(subIssue, false, false))
+        );
+        
+        return { 
+          content: [{ 
+            type: 'text', 
+            text: JSON.stringify({
+              parentId,
+              parentTitle: parentIssue.title,
+              parentIdentifier: parentIssue.identifier,
+              subIssues: detailedSubIssues,
+              totalCount: subIssuesConnection.nodes.length
+            })
+          }] 
+        };
+      } else {
+        // Return simplified sub-issue list
+        const simplifiedSubIssues = subIssuesConnection.nodes.map(subIssue => ({
+          id: subIssue.id,
+          identifier: subIssue.identifier,
+          title: subIssue.title,
+          priority: subIssue.priority,
+          url: subIssue.url
+        }));
+        
+        return { 
+          content: [{ 
+            type: 'text', 
+            text: JSON.stringify({
+              parentId,
+              parentTitle: parentIssue.title,
+              parentIdentifier: parentIssue.identifier,
+              subIssues: simplifiedSubIssues,
+              totalCount: subIssuesConnection.nodes.length
+            })
+          }] 
+        };
+      }
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list sub-issues: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 

--- a/src/tools/issues/mappers.test.ts
+++ b/src/tools/issues/mappers.test.ts
@@ -1,7 +1,7 @@
 // Unit test for mapIssueToDetails in issues module
 
 import { describe, expect, it } from 'vitest';
-import { mapIssueToDetails } from './mappers.js';
+import { mapIssueToDetails } from './shared.js';
 
 describe('mapIssueToDetails', () => {
   it('should be a function', () => {

--- a/src/tools/issues/remove_issue_parent.ts
+++ b/src/tools/issues/remove_issue_parent.ts
@@ -1,0 +1,74 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+import { mapIssueToDetails } from './shared.js';
+
+const RemoveIssueParentSchema = {
+  issueId: z.string().describe('The ID of the sub-issue to convert back to a regular issue'),
+};
+
+export const removeIssueParentTool = defineTool({
+  name: 'remove_issue_parent',
+  description: 'Remove the parent from a sub-issue, converting it back to a regular issue',
+  inputSchema: RemoveIssueParentSchema,
+  handler: async ({ issueId }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Get the issue to verify it exists
+      const issue = await linearClient.issue(issueId);
+      if (!issue) {
+        throw new McpError(ErrorCode.InvalidParams, `Issue with ID '${issueId}' not found.`);
+      }
+
+      // Check if issue has a parent
+      const currentParent = await issue.parent;
+      if (!currentParent) {
+        throw new McpError(
+          ErrorCode.InvalidParams, 
+          `Issue '${issue.identifier}' is not a sub-issue (has no parent).`
+        );
+      }
+
+      // Update the issue to remove the parent
+      const issueUpdate = await linearClient.updateIssue(issueId, {
+        parentId: null
+      });
+      
+      const updatedIssue = await issueUpdate.issue;
+      if (!updatedIssue) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to update issue or retrieve details. Sync ID: ${issueUpdate.lastSyncId}`
+        );
+      }
+
+      // Return detailed information about the updated issue
+      const detailedIssue = await mapIssueToDetails(updatedIssue, false, false);
+      
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify({
+            success: true,
+            issue: detailedIssue,
+            removedParent: {
+              id: currentParent.id,
+              identifier: currentParent.identifier,
+              title: currentParent.title
+            },
+            syncId: issueUpdate.lastSyncId
+          })
+        }] 
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to remove issue parent: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 

--- a/src/tools/issues/set_issue_parent.ts
+++ b/src/tools/issues/set_issue_parent.ts
@@ -1,0 +1,95 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+import { mapIssueToDetails } from './shared.js';
+
+const SetIssueParentSchema = {
+  issueId: z.string().describe('The ID of the issue to convert to a sub-issue'),
+  parentId: z.string().describe('The ID of the parent issue'),
+  replaceExistingParent: z.boolean().default(false).describe('Whether to replace an existing parent if the issue already has one'),
+};
+
+export const setIssueParentTool = defineTool({
+  name: 'set_issue_parent',
+  description: 'Convert an existing issue into a sub-issue by setting its parent',
+  inputSchema: SetIssueParentSchema,
+  handler: async ({ issueId, parentId, replaceExistingParent }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Get both issues to verify they exist
+      const [issue, parentIssue] = await Promise.all([
+        linearClient.issue(issueId),
+        linearClient.issue(parentId)
+      ]);
+      
+      if (!issue) {
+        throw new McpError(ErrorCode.InvalidParams, `Issue with ID '${issueId}' not found.`);
+      }
+      
+      if (!parentIssue) {
+        throw new McpError(ErrorCode.InvalidParams, `Parent issue with ID '${parentId}' not found.`);
+      }
+
+      // Check if issue already has a parent
+      const currentParent = await issue.parent;
+      if (currentParent && !replaceExistingParent) {
+        throw new McpError(
+          ErrorCode.InvalidParams, 
+          `Issue '${issue.identifier}' already has a parent issue '${currentParent.identifier}'. Set replaceExistingParent to true to replace it.`
+        );
+      }
+
+      // Verify both issues are in the same team (Linear requirement)
+      if (issue.teamId !== parentIssue.teamId) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Issue and parent must be in the same team. Issue is in team '${issue.teamId}', parent is in team '${parentIssue.teamId}'.`
+        );
+      }
+
+      // Update the issue to set the parent
+      const issueUpdate = await linearClient.updateIssue(issueId, {
+        parentId: parentId
+      });
+      
+      const updatedIssue = await issueUpdate.issue;
+      if (!updatedIssue) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to update issue or retrieve details. Sync ID: ${issueUpdate.lastSyncId}`
+        );
+      }
+
+      // Return detailed information about the updated sub-issue
+      const detailedSubIssue = await mapIssueToDetails(updatedIssue, false, false);
+      
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify({
+            success: true,
+            subIssue: detailedSubIssue,
+            parentId,
+            parentTitle: parentIssue.title,
+            parentIdentifier: parentIssue.identifier,
+            previousParent: currentParent ? {
+              id: currentParent.id,
+              identifier: currentParent.identifier,
+              title: currentParent.title
+            } : null,
+            syncId: issueUpdate.lastSyncId
+          })
+        }] 
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to set issue parent: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 

--- a/src/tools/issues/update_issue.ts
+++ b/src/tools/issues/update_issue.ts
@@ -17,13 +17,14 @@ const IssueUpdateSchema = {
   labelIds: z.array(z.string()).optional().describe('Label IDs'),
   stateId: z.string().optional().describe('Workflow state ID'),
   projectId: z.string().optional().describe('Project ID to assign the issue to'),
+  projectMilestoneId: z.string().optional().describe('Project milestone ID to assign the issue to'),
 };
 
 export const updateIssueTool = defineTool({
   name: 'update_issue',
   description: 'Update an existing Linear issue',
   inputSchema: IssueUpdateSchema,
-  handler: async ({ id, title, description, priority, assigneeId, labelIds, stateId, projectId }) => {
+  handler: async ({ id, title, description, priority, assigneeId, labelIds, stateId, projectId, projectMilestoneId }) => {
     const linearClient = getLinearClient();
 
     // Get the issue to update
@@ -41,6 +42,7 @@ export const updateIssueTool = defineTool({
       ...(labelIds !== undefined && { labelIds }),
       ...(stateId !== undefined && { stateId }),
       ...(projectId !== undefined && { projectId }),
+      ...(projectMilestoneId !== undefined && { projectMilestoneId }),
     };
 
     // Update the issue

--- a/src/tools/issues/update_issue.ts
+++ b/src/tools/issues/update_issue.ts
@@ -16,13 +16,14 @@ const IssueUpdateSchema = {
   assigneeId: z.string().optional().describe('Assignee user ID'),
   labelIds: z.array(z.string()).optional().describe('Label IDs'),
   stateId: z.string().optional().describe('Workflow state ID'),
+  projectId: z.string().optional().describe('Project ID to assign the issue to'),
 };
 
 export const updateIssueTool = defineTool({
   name: 'update_issue',
   description: 'Update an existing Linear issue',
   inputSchema: IssueUpdateSchema,
-  handler: async ({ id, title, description, priority, assigneeId, labelIds, stateId }) => {
+  handler: async ({ id, title, description, priority, assigneeId, labelIds, stateId, projectId }) => {
     const linearClient = getLinearClient();
 
     // Get the issue to update
@@ -39,6 +40,7 @@ export const updateIssueTool = defineTool({
       ...(assigneeId !== undefined && { assigneeId }),
       ...(labelIds !== undefined && { labelIds }),
       ...(stateId !== undefined && { stateId }),
+      ...(projectId !== undefined && { projectId }),
     };
 
     // Update the issue

--- a/src/tools/projects/create_project_update.ts
+++ b/src/tools/projects/create_project_update.ts
@@ -1,0 +1,77 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+
+const CreateProjectUpdateSchema = {
+  projectId: z.string().describe('The ID of the project to create an update for'),
+  body: z.string().describe('The update content in markdown format'),
+  isDiffHidden: z.boolean().default(false).describe('Whether to hide the diff from previous update'),
+};
+
+export const createProjectUpdateTool = defineTool({
+  name: 'create_project_update',
+  description: 'Create a new project update',
+  inputSchema: CreateProjectUpdateSchema,
+  handler: async ({ projectId, body, isDiffHidden }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Verify the project exists first
+      const project = await linearClient.project(projectId);
+      if (!project) {
+        throw new McpError(ErrorCode.InvalidParams, `Project with ID '${projectId}' not found.`);
+      }
+
+      // Create the project update
+      const createPayload = await linearClient.createProjectUpdate({
+        projectId,
+        body,
+        isDiffHidden,
+      });
+      
+      const newUpdate = await createPayload.projectUpdate;
+      if (!newUpdate) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to create project update or retrieve details. Sync ID: ${createPayload.lastSyncId}`
+        );
+      }
+
+      // Return detailed information about the created update
+      const updateDetails = {
+        id: newUpdate.id,
+        body: newUpdate.body,
+        projectId: newUpdate.projectId,
+        userId: newUpdate.userId,
+        createdAt: newUpdate.createdAt.toISOString(),
+        editedAt: newUpdate.editedAt?.toISOString() || null,
+        isStale: newUpdate.isStale,
+        isDiffHidden: newUpdate.isDiffHidden,
+        diff: newUpdate.diff,
+        diffMarkdown: newUpdate.diffMarkdown,
+        url: newUpdate.url,
+      };
+      
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify({
+            success: true,
+            projectUpdate: updateDetails,
+            projectName: project.name,
+            projectState: project.state,
+            syncId: createPayload.lastSyncId
+          })
+        }] 
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to create project update: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 

--- a/src/tools/projects/get_project_update.ts
+++ b/src/tools/projects/get_project_update.ts
@@ -1,0 +1,75 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+
+const GetProjectUpdateSchema = {
+  updateId: z.string().describe('The ID of the project update to retrieve'),
+};
+
+export const getProjectUpdateTool = defineTool({
+  name: 'get_project_update',
+  description: 'Get details of a specific project update',
+  inputSchema: GetProjectUpdateSchema,
+  handler: async ({ updateId }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Get the project update
+      const update = await linearClient.projectUpdate(updateId);
+      if (!update) {
+        throw new McpError(ErrorCode.InvalidParams, `Project update with ID '${updateId}' not found.`);
+      }
+
+      // Get the project and user information
+      const [project, user] = await Promise.all([
+        update.project,
+        update.user
+      ]);
+
+      // Return detailed information about the update
+      const updateDetails = {
+        id: update.id,
+        body: update.body,
+        projectId: update.projectId,
+        userId: update.userId,
+        createdAt: update.createdAt.toISOString(),
+        editedAt: update.editedAt?.toISOString() || null,
+        archivedAt: update.archivedAt?.toISOString() || null,
+        isStale: update.isStale,
+        isDiffHidden: update.isDiffHidden,
+        diff: update.diff,
+        diffMarkdown: update.diffMarkdown,
+        url: update.url,
+        
+        // Related entities
+        project: project ? {
+          id: project.id,
+          name: project.name,
+          state: project.state,
+          url: project.url
+        } : null,
+        user: user ? {
+          id: user.id,
+          name: user.name,
+          displayName: user.displayName,
+          email: user.email
+        } : null,
+      };
+      
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify(updateDetails)
+        }] 
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get project update: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 

--- a/src/tools/projects/index.ts
+++ b/src/tools/projects/index.ts
@@ -2,8 +2,20 @@ import { createProjectTool } from './create_project.js';
 import { listProjectsTool } from './list_projects.js';
 import { updateProjectTool } from './update_project.js';
 
+// Project update tools
+import { listProjectUpdatesTool } from './list_project_updates.js';
+import { createProjectUpdateTool } from './create_project_update.js';
+import { updateProjectUpdateTool } from './update_project_update.js';
+import { getProjectUpdateTool } from './get_project_update.js';
+
 export const projectTools = [
   createProjectTool,
   listProjectsTool,
   updateProjectTool,
+  
+  // Project update tools
+  listProjectUpdatesTool,
+  createProjectUpdateTool,
+  updateProjectUpdateTool,
+  getProjectUpdateTool,
 ];

--- a/src/tools/projects/list_project_updates.ts
+++ b/src/tools/projects/list_project_updates.ts
@@ -1,0 +1,69 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+
+const ListProjectUpdatesSchema = {
+  projectId: z.string().describe('The ID of the project to list updates for'),
+  includeArchived: z.boolean().default(false).describe('Whether to include archived updates'),
+  limit: z.number().min(1).max(100).default(20).describe('Maximum number of updates to return'),
+};
+
+export const listProjectUpdatesTool = defineTool({
+  name: 'list_project_updates',
+  description: 'List updates for a given project',
+  inputSchema: ListProjectUpdatesSchema,
+  handler: async ({ projectId, includeArchived, limit }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Get the project first to verify it exists
+      const project = await linearClient.project(projectId);
+      if (!project) {
+        throw new McpError(ErrorCode.InvalidParams, `Project with ID '${projectId}' not found.`);
+      }
+
+      // Get the project updates
+      const projectUpdatesConnection = await project.projectUpdates({
+        includeArchived,
+        first: limit,
+      });
+      
+      const updates = projectUpdatesConnection.nodes.map(update => ({
+        id: update.id,
+        body: update.body,
+        createdAt: update.createdAt.toISOString(),
+        editedAt: update.editedAt?.toISOString() || null,
+        userId: update.userId,
+        projectId: update.projectId,
+        isStale: update.isStale,
+        isDiffHidden: update.isDiffHidden,
+        diff: update.diff,
+        diffMarkdown: update.diffMarkdown,
+        archivedAt: update.archivedAt?.toISOString() || null,
+        url: update.url,
+      }));
+      
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify({
+            projectId,
+            projectName: project.name,
+            projectState: project.state,
+            updates,
+            totalCount: updates.length,
+            hasNextPage: projectUpdatesConnection.pageInfo.hasNextPage,
+          })
+        }] 
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to list project updates: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 

--- a/src/tools/projects/update_project_update.ts
+++ b/src/tools/projects/update_project_update.ts
@@ -1,0 +1,86 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { getLinearClient } from '../../utils/linear-client.js';
+import { defineTool } from '../shared/tool-definition.js';
+import { z } from 'zod';
+
+const UpdateProjectUpdateSchema = {
+  updateId: z.string().describe('The ID of the project update to modify'),
+  body: z.string().optional().describe('The updated content in markdown format'),
+  isDiffHidden: z.boolean().optional().describe('Whether to hide the diff from previous update'),
+};
+
+export const updateProjectUpdateTool = defineTool({
+  name: 'update_project_update',
+  description: 'Update an existing project update',
+  inputSchema: UpdateProjectUpdateSchema,
+  handler: async ({ updateId, body, isDiffHidden }) => {
+    try {
+      const linearClient = getLinearClient();
+      
+      // Verify the update exists first
+      const existingUpdate = await linearClient.projectUpdate(updateId);
+      if (!existingUpdate) {
+        throw new McpError(ErrorCode.InvalidParams, `Project update with ID '${updateId}' not found.`);
+      }
+
+      // Build the update payload with only provided fields
+      const updatePayload: any = {};
+      if (body !== undefined) updatePayload.body = body;
+      if (isDiffHidden !== undefined) updatePayload.isDiffHidden = isDiffHidden;
+
+      if (Object.keys(updatePayload).length === 0) {
+        throw new McpError(ErrorCode.InvalidParams, 'At least one field (body or isDiffHidden) must be provided for update.');
+      }
+
+      // Update the project update
+      const updateResult = await linearClient.updateProjectUpdate(updateId, updatePayload);
+      
+      const updatedUpdate = await updateResult.projectUpdate;
+      if (!updatedUpdate) {
+        throw new McpError(
+          ErrorCode.InternalError,
+          `Failed to update project update or retrieve details. Sync ID: ${updateResult.lastSyncId}`
+        );
+      }
+
+      // Return detailed information about the updated update
+      const updateDetails = {
+        id: updatedUpdate.id,
+        body: updatedUpdate.body,
+        projectId: updatedUpdate.projectId,
+        userId: updatedUpdate.userId,
+        createdAt: updatedUpdate.createdAt.toISOString(),
+        editedAt: updatedUpdate.editedAt?.toISOString() || null,
+        isStale: updatedUpdate.isStale,
+        isDiffHidden: updatedUpdate.isDiffHidden,
+        diff: updatedUpdate.diff,
+        diffMarkdown: updatedUpdate.diffMarkdown,
+        url: updatedUpdate.url,
+      };
+
+      // Get project info for context
+      const project = await updatedUpdate.project;
+      
+      return { 
+        content: [{ 
+          type: 'text', 
+          text: JSON.stringify({
+            success: true,
+            projectUpdate: updateDetails,
+            projectName: project?.name || 'Unknown',
+            projectState: project?.state || 'Unknown',
+            changedFields: Object.keys(updatePayload),
+            syncId: updateResult.lastSyncId
+          })
+        }] 
+      };
+    } catch (error) {
+      if (error instanceof McpError) throw error;
+      
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to update project update: ${(error as Error).message || 'Unknown error'}`
+      );
+    }
+  },
+}); 


### PR DESCRIPTION
# Add Sub-Issue Management and Project Documentation Features

## 🚀 New Features

### Sub-Issue Management
- **`list_sub_issues`** - List all sub-issues for a parent issue
- **`create_sub_issue`** - Create sub-issues with property inheritance
- **`set_issue_parent`** - Convert existing issues to sub-issues
- **`remove_issue_parent`** - Convert sub-issues back to regular issues

### Project Documentation System  
- **`list_project_updates`** - List project updates with pagination
- **`create_project_update`** - Create rich markdown project updates
- **`update_project_update`** - Edit existing project updates with diff tracking
- **`get_project_update`** - Retrieve detailed project update information

## 🔧 Fixes
- Fixed duplicate tool registration issue (`list_my_issues`)

## 📊 Impact
- **+8 new MCP tools** (from 7 to 15 total tools)