### PR TITLE
docs: add MCP family SOTA roadmap

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,33 @@
+# Linear MCP
+
+Linear MCP is an archived connector MCP for Linear workspace operations. Its
+family role is connector reference and possible future integration substrate,
+not core evidence, code intelligence, reader, filesystem, or consultation
+infrastructure.
+
+## Lifecycle
+
+- State: `archived`
+- Layer: `connector`
+
+## Goals
+
+- Preserve a clear boundary for Linear issue, project, team, user, label, and
+  milestone MCP operations.
+- Document what would be required before any reactivation.
+- Avoid confusing users into treating an archived connector as a current
+  flagship MCP.
+
+## Non-Goals
+
+- This repository does not own SylphxAI project management policy.
+- This repository does not own the MCP family evidence envelope or code
+  intelligence stack.
+- This repository does not own Linear account governance, tenant policy, or
+  enterprise workflow automation.
+
+## Public Surfaces
+
+- Package manifest: [`package.json`](package.json)
+- Public README: [`README.md`](README.md)
+- SOTA family roadmap: [`docs/roadmap/sota-family-roadmap.md`](docs/roadmap/sota-family-roadmap.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server for interacting with Linear issues, projects, teams, project milestones and more.
 
+SOTA family roadmap: [docs/roadmap/sota-family-roadmap.md](docs/roadmap/sota-family-roadmap.md).
+
 ## Features
 
 - List, get, create, and update issues

--- a/docs/adr/ADR-25-mcp-family-sota-roadmap.md
+++ b/docs/adr/ADR-25-mcp-family-sota-roadmap.md
@@ -1,0 +1,31 @@
+# ADR-25: Adopt Linear MCP Family SOTA Roadmap
+
+Date: 2026-07-09
+Status: Proposed in PR #25
+Slug: mcp-family-sota-roadmap
+
+## Context
+
+Linear MCP is an archived connector MCP. It should have a clear future state so
+it does not blur the family boundary between flagship MCP products and archived
+connector references.
+
+## Decision
+
+Adopt `docs/roadmap/sota-family-roadmap.md` as the repo-local roadmap.
+
+Linear MCP remains archived unless a future ADR reactivates it with auth,
+scope, pagination, rate-limit, write-policy, audit, and package gates.
+
+## Consequences
+
+- No package release should occur while archived.
+- The core family roadmap should not depend on this connector.
+- If reactivated, write-capable Linear operations need operation evidence,
+  idempotency, and failure semantics.
+
+## Verification
+
+- Roadmap added at `docs/roadmap/sota-family-roadmap.md`.
+- PROJECT and README link to the roadmap.
+- Docs-only validation: `git diff --check`.

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -1,0 +1,61 @@
+# SOTA Family Roadmap
+
+Status: archived adoption plan
+Owner: Linear MCP
+Scope: repo-local future plan and its role in the SylphxAI MCP family
+Decision record: pending PR-number ADR
+
+## Family Role
+
+Linear MCP is a connector MCP. It gives agents access to Linear issues,
+projects, teams, users, statuses, labels, comments, and milestones. It is not a
+core family substrate like Reader, CodeRAG, Architecture Reader, Filesystem, or
+Consultant MCP.
+
+Because the repository is archived, its current family role is reference and
+possible future reactivation, not active distribution.
+
+## Family Fit
+
+| Project | Relationship |
+| --- | --- |
+| Consultant MCP | May use connector outputs as evidence for delivery review only if reactivated. |
+| Architecture Reader MCP | May link Linear project metadata to ownership or roadmap context only through explicit integration. |
+| Filesystem MCP | No direct dependency; file operations stay separate from SaaS connector behavior. |
+| CodeRAG and Reader MCPs | No direct dependency. |
+
+## SOTA End State
+
+If this connector is reactivated, it should be a secure, least-privilege,
+auditable Linear connector with clear auth, pagination, rate-limit, write
+policy, and operation evidence. If not reactivated, it should remain archived
+and clearly point users to the current supported connector path.
+
+## Roadmap
+
+### Phase 0: Archive Clarity
+
+- Keep the archived status explicit.
+- Document that active flagship MCP work lives in the evidence, code
+  intelligence, filesystem, and consultant repos.
+- Do not publish new package versions while archived.
+
+### Phase 1: Reactivation Bar
+
+- Add project manifest and ADR before any code changes.
+- Add auth, scope, pagination, rate-limit, retry, idempotency, and audit-policy
+  tests.
+- Add clear read vs write tool boundaries and dry-run mode for write tools.
+
+### Phase 2: Family Integration
+
+- If reactivated, emit evidence envelopes for issue/project operations.
+- Allow Consultant MCP to review delivery state from Linear evidence without
+  embedding Linear-specific policy in Consultant MCP.
+
+## Validation Gates
+
+- No package release while archived.
+- Reactivation requires CI, package smoke, auth-scope tests, and write-policy
+  tests.
+- Every write-capable tool exposes operation evidence and failure semantics.

--- a/docs/roadmap/sota-family-roadmap.md
+++ b/docs/roadmap/sota-family-roadmap.md
@@ -3,7 +3,7 @@
 Status: archived adoption plan
 Owner: Linear MCP
 Scope: repo-local future plan and its role in the SylphxAI MCP family
-Decision record: pending PR-number ADR
+Decision record: `docs/adr/ADR-25-mcp-family-sota-roadmap.md`
 
 ## Family Role
 


### PR DESCRIPTION
## Summary
- add repo-local SOTA family roadmap for Linear MCP
- add ADR-25 adopting archived connector roadmap
- add PROJECT.md boundary for archived connector state

## Validation
- local: git diff origin/main...HEAD --check
- remote: no required checks configured