### PR TITLE
docs: mark archived MCP ADR accepted

### DIFF
--- a/docs/adr/ADR-25-mcp-family-sota-roadmap.md
+++ b/docs/adr/ADR-25-mcp-family-sota-roadmap.md
@@ -1,7 +1,7 @@
 # ADR-25: Adopt Linear MCP Family SOTA Roadmap
 
 Date: 2026-07-09
-Status: Proposed in PR #25
+Status: Accepted
 Slug: mcp-family-sota-roadmap
 
 ## Context


### PR DESCRIPTION
## Summary
- mark the merged archived MCP family ADR as accepted
- remove stale proposed-state wording while preserving archive handoff intent

## Validation
- git diff --check